### PR TITLE
[Feat]: 로그인 뷰 퍼블리싱

### DIFF
--- a/KB-Hackerton-client/src/components/common/BaseButton.vue
+++ b/KB-Hackerton-client/src/components/common/BaseButton.vue
@@ -1,0 +1,22 @@
+<script setup>
+defineProps({
+  type: { type: String, default: 'button' },
+  color: { type: String, default: 'main' },
+  disabled: Boolean,
+})
+</script>
+
+<template>
+  <button
+    :type="type"
+    :disabled="disabled"
+    :class="[
+      'mx-auto w-[340px] h-[40px] rounded-xl font-bold text-20 flex items-center justify-center',
+      disabled ? 'bg-gray-300 text-white cursor-not-allowed' : '',
+      color === 'main' ? 'bg-main text-white' : '',
+      color === 'yellow' ? 'bg-yellow text-black' : '',
+    ]"
+  >
+    <slot />
+  </button>
+</template>

--- a/KB-Hackerton-client/src/components/common/BaseInput.vue
+++ b/KB-Hackerton-client/src/components/common/BaseInput.vue
@@ -1,0 +1,26 @@
+<script setup>
+defineProps({
+  id: String,
+  type: { type: String, default: 'text' },
+  modelValue: String,
+  placeholder: String,
+  autocomplete: String,
+  label: String,
+})
+defineEmits(['update:modelValue'])
+</script>
+
+<template>
+  <div>
+    <label :for="id" class="block text-16 text-gray-300">{{ label }}</label>
+    <input
+      :id="id"
+      :type="type"
+      :value="modelValue"
+      :placeholder="placeholder"
+      :autocomplete="autocomplete"
+      class="w-full border-b border-gray-200 py-2 text-16 outline-none placeholder:text-gray-200"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
+  </div>
+</template>

--- a/KB-Hackerton-client/src/components/layouts/BottomNavigationBar.vue
+++ b/KB-Hackerton-client/src/components/layouts/BottomNavigationBar.vue
@@ -5,7 +5,7 @@ import { useRoute } from 'vue-router'
 import { computed } from 'vue'
 const route = useRoute()
 
-const hiddenPrefixes = []
+const hiddenPrefixes = ['/login']
 
 const isHidden = computed(() => hiddenPrefixes.some((prefix) => route.path.startsWith(prefix)))
 </script>

--- a/KB-Hackerton-client/src/router/index.js
+++ b/KB-Hackerton-client/src/router/index.js
@@ -2,6 +2,8 @@ import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import DefaultLayout from '@/components/layouts/DefaultLayout.vue'
 
+import user from '@/router/user.js'
+
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
@@ -57,6 +59,7 @@ const router = createRouter({
             title: '알림',
           },
         },
+        ...user,
       ],
     },
   ],

--- a/KB-Hackerton-client/src/router/user.js
+++ b/KB-Hackerton-client/src/router/user.js
@@ -1,0 +1,19 @@
+export default [
+  {
+    path: '/login',
+    name: 'login',
+    component: () => import('@/views/LoginView.vue'),
+  },
+  // {
+  //   path: 'join',
+  //   name: 'join',
+  //   component: () => import('@/views/JoinView.vue'),
+  //   meta: { title: '회원 가입' },
+  // },
+  // {
+  //   path: 'find-password',
+  //   name: 'find-password',
+  //   component: () => import('@/views/FindPasswordView.vue'),
+  //   meta: { title: '비밀번호 찾기' },
+  // },
+]

--- a/KB-Hackerton-client/src/stores/auth.js
+++ b/KB-Hackerton-client/src/stores/auth.js
@@ -1,0 +1,61 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+export const useAuthStore = defineStore('auth', () => {
+  const token = ref(null)
+  const user = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  // 더미 계정
+  const dummy = {
+    memberId: 1,
+    businessId: 1,
+    profileImageId: 1,
+    email: 'test@test.com',
+    memberName: '김감자',
+    createdAt: '2025-09-02T04:12:45.000+00:00',
+    helpCount: 10,
+    badge: '도움왕',
+    authMap: [{ authority: 'Member' }],
+  }
+
+  // 로그인
+  async function loginUser(email, password) {
+    if (loading.value) return
+    loading.value = true
+    error.value = null
+
+    try {
+      await new Promise((r) => setTimeout(r, 500)) // 더미 API 딜레이
+
+      // 더미 계정 검증
+      if (email === 'test@test.com' && password === '1234') {
+        token.value = 'dummy-token'
+        user.value = dummy
+
+        localStorage.setItem('accessToken', token.value)
+        localStorage.setItem('user', JSON.stringify(user.value))
+        return true
+      } else {
+        error.value = '이메일 또는 비밀번호가 올바르지 않습니다.'
+        return false
+      }
+    } catch (e) {
+      error.value = e.message || '로그인에 실패했습니다.'
+      return false
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // 로그아웃
+  function logoutUser() {
+    token.value = null
+    user.value = null
+    localStorage.removeItem('accessToken')
+    localStorage.removeItem('user')
+  }
+
+  return { user, token, loading, error, loginUser, logoutUser }
+})

--- a/KB-Hackerton-client/src/views/LoginView.vue
+++ b/KB-Hackerton-client/src/views/LoginView.vue
@@ -1,0 +1,61 @@
+<script setup>
+import logoUrl from '@/assets/images/svg/mainLogo.svg?url'
+</script>
+
+<template>
+  <div class="w-full h-full bg-white p-3">
+    <!-- 로고 -->
+    <img
+      :src="logoUrl"
+      alt="경상났네 로고"
+      class="block h-[280px] w-auto object-contain object-center mx-auto mt-3 mb-10"
+    />
+
+    <!-- 로그인 폼 -->
+    <form class="flex flex-col gap-8">
+      <div>
+        <label for="email" class="block text-16 text-gray-300">이메일</label>
+        <input
+          id="email"
+          type="email"
+          placeholder="이메일을 입력해 주세요."
+          class="w-full border-b border-gray-200 py-2 text-16 outline-none placeholder:text-gray-200"
+        />
+      </div>
+
+      <div>
+        <label for="password" class="block text-16 text-gray-300">비밀번호</label>
+        <input
+          id="password"
+          type="password"
+          placeholder="비밀번호를 입력해 주세요."
+          class="w-full border-b border-gray-200 py-2 text-16 outline-none placeholder:text-gray-200"
+        />
+      </div>
+
+      <button
+        type="submit"
+        class="mx-auto w-[340px] h-[40px] bg-main text-white rounded-xl font-bold text-20 mt-2"
+      >
+        로그인
+      </button>
+    </form>
+
+    <!-- 카카오 로그인 -->
+    <button
+      type="button"
+      class="mx-auto w-[340px] h-[40px] bg-yellow text-black rounded-xl font-bold text-20 mt-4 flex items-center justify-center"
+    >
+      카카오로 이용하기
+    </button>
+
+    <!-- 하단 링크 -->
+    <nav class="mt-10 flex justify-center gap-3 text-16 text-black">
+      <RouterLink to="/find-password">비밀번호 찾기</RouterLink>
+      <span> · </span>
+      <RouterLink to="/signup">회원가입</RouterLink>
+    </nav>
+  </div>
+</template>
+
+<style scoped></style>

--- a/KB-Hackerton-client/src/views/LoginView.vue
+++ b/KB-Hackerton-client/src/views/LoginView.vue
@@ -3,6 +3,8 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import logoUrl from '@/assets/images/svg/mainLogo.svg?url'
+import BaseInput from '@/components/common/BaseInput.vue'
+import BaseButton from '@/components/common/BaseButton.vue'
 
 const router = useRouter()
 const auth = useAuthStore()
@@ -29,47 +31,33 @@ async function onSubmit() {
 
     <!-- 로그인 폼 -->
     <form class="flex flex-col gap-6" @submit.prevent="onSubmit">
-      <div>
-        <label for="email" class="block text-16 text-gray-300">이메일</label>
-        <input
-          id="email"
-          v-model.trim="email"
-          type="email"
-          autocomplete="email"
-          placeholder="이메일을 입력해 주세요."
-          class="w-full border-b border-gray-200 py-2 text-16 outline-none placeholder:text-gray-200"
-        />
-      </div>
+      <BaseInput
+        id="email"
+        v-model="email"
+        type="email"
+        label="이메일"
+        placeholder="이메일을 입력해주세요."
+        autocomplete="email"
+      />
 
-      <div>
-        <label for="password" class="block text-16 text-gray-300">비밀번호</label>
-        <input
-          id="password"
-          v-model.trim="password"
-          type="password"
-          autocomplete="current-password"
-          placeholder="비밀번호를 입력해 주세요."
-          class="w-full border-b border-gray-200 py-2 text-16 outline-none placeholder:text-gray-200"
-        />
-      </div>
+      <BaseInput
+        id="password"
+        v-model="password"
+        type="password"
+        label="비밀번호"
+        placeholder="비밀번호를 입력해 주세요."
+        autocomplete="current-password"
+      />
 
       <p v-if="auth.error" class="text-red font-bold text-10 -mt-2 mb-1">{{ auth.error }}</p>
 
-      <button
-        type="submit"
-        class="mx-auto w-[340px] h-[40px] bg-main text-white rounded-xl font-bold text-20 mt-2"
-      >
+      <BaseButton type="submit" color="main">
         {{ auth.loading ? '로그인 중...' : '로그인' }}
-      </button>
+      </BaseButton>
     </form>
 
     <!-- 카카오 로그인 -->
-    <button
-      type="button"
-      class="mx-auto w-[340px] h-[40px] bg-yellow text-black rounded-xl font-bold text-20 mt-4 flex items-center justify-center"
-    >
-      카카오로 이용하기
-    </button>
+    <BaseButton color="yellow" class="mt-4">카카오로 이용하기</BaseButton>
 
     <!-- 하단 링크 -->
     <nav class="mt-10 flex justify-center gap-3 text-16 text-black">

--- a/KB-Hackerton-client/src/views/LoginView.vue
+++ b/KB-Hackerton-client/src/views/LoginView.vue
@@ -1,5 +1,21 @@
 <script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 import logoUrl from '@/assets/images/svg/mainLogo.svg?url'
+
+const router = useRouter()
+const auth = useAuthStore()
+
+const email = ref('')
+const password = ref('')
+
+async function onSubmit() {
+  const ok = await auth.loginUser(email.value, password.value)
+  if (ok) {
+    router.replace('/') // 로그인 성공 → 홈으로 이동
+  }
+}
 </script>
 
 <template>
@@ -12,12 +28,14 @@ import logoUrl from '@/assets/images/svg/mainLogo.svg?url'
     />
 
     <!-- 로그인 폼 -->
-    <form class="flex flex-col gap-8">
+    <form class="flex flex-col gap-6" @submit.prevent="onSubmit">
       <div>
         <label for="email" class="block text-16 text-gray-300">이메일</label>
         <input
           id="email"
+          v-model.trim="email"
           type="email"
+          autocomplete="email"
           placeholder="이메일을 입력해 주세요."
           class="w-full border-b border-gray-200 py-2 text-16 outline-none placeholder:text-gray-200"
         />
@@ -27,17 +45,21 @@ import logoUrl from '@/assets/images/svg/mainLogo.svg?url'
         <label for="password" class="block text-16 text-gray-300">비밀번호</label>
         <input
           id="password"
+          v-model.trim="password"
           type="password"
+          autocomplete="current-password"
           placeholder="비밀번호를 입력해 주세요."
           class="w-full border-b border-gray-200 py-2 text-16 outline-none placeholder:text-gray-200"
         />
       </div>
 
+      <p v-if="auth.error" class="text-red font-bold text-10 -mt-2 mb-1">{{ auth.error }}</p>
+
       <button
         type="submit"
         class="mx-auto w-[340px] h-[40px] bg-main text-white rounded-xl font-bold text-20 mt-2"
       >
-        로그인
+        {{ auth.loading ? '로그인 중...' : '로그인' }}
       </button>
     </form>
 


### PR DESCRIPTION
<!--- 제목 ex: [Feat]: 회원가입 -->

## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #이슈번호
> Close #6

## 📄 PR 상세 내용
<!--- 작업에 대한 설명을 작성해 주세요. -->
- Figma 디자인 시안 기반으로 Vue 컴포넌트(LoginView.vue) 퍼블리싱 진행
- 공통 UI 스타일 적용 (폰트, 버튼 스타일, 인풋 필드 스타일)
- Pinia 스토어(useAuthStore)를 생성하여 로그인 상태 관리
- 더미 계정([test@test.com](mailto:test@test.com) / 1234)으로 로그인 검증
- 로그인 성공 시: token과 user를 상태 및 localStorage에 저장
- 로그인 실패 시: error 메시지를 표시
- 로그아웃 시 상태 초기화 및 localStorage에서 데이터 제거

## 📸 이미지 
<img width="250" alt="image" src="https://github.com/user-attachments/assets/1c4ab9a1-fd14-4aba-8d2f-023c56e4f1f2" />


## ❓ 논의하고 싶은 내용

## 📍 레퍼런스
