### PR TITLE
[Feat]: 즐겨찾기 목록 뷰 퍼블리싱

### DIFF
--- a/KB-Hackerton-client/src/_dummy/announce.json
+++ b/KB-Hackerton-client/src/_dummy/announce.json
@@ -16,8 +16,8 @@
     "how_to_register": "온라인 신청 시스템을 통해 접수",
     "call_company": "중소기업통합콜센터(1357)",
     "reqst_start_date": "20250901",
-    "reqst_end_date": "20250901",
-    "is_favorite": false
+    "reqst_end_date": "",
+    "is_favorite": true
   },
   {
     "announce_id": 2,
@@ -36,7 +36,7 @@
     "how_to_register": "사업 전용 홈페이지에서 온라인 접수",
     "call_company": "산업기술진흥원 상담센터(1234-5678)",
     "reqst_start_date": "20250902",
-    "reqst_end_date": "20250905",
+    "reqst_end_date": "20250904",
     "is_favorite": true
   },
   {
@@ -235,8 +235,8 @@
     "hashtags": "#경영",
     "how_to_register": "온라인 접수 후 서면평가",
     "call_company": "KoSEA 고객센터(031-000-0000)",
-    "reqst_start_date": "20250918",
-    "reqst_end_date": "20251002",
+    "reqst_start_date": "20250803",
+    "reqst_end_date": "20250907",
     "is_favorite": true
   },
   {

--- a/KB-Hackerton-client/src/components/favorite/FavoriteCard.vue
+++ b/KB-Hackerton-client/src/components/favorite/FavoriteCard.vue
@@ -1,0 +1,90 @@
+<script setup>
+import { Icon } from '@iconify/vue'
+import { computed, defineProps } from 'vue'
+import { RouterLink } from 'vue-router'
+
+const props = defineProps({
+  favorite: {
+    type: Object,
+    required: true,
+  },
+})
+
+function parseDate(yyyymmdd) {
+  const yyyy = yyyymmdd.slice(0, 4)
+  const mm = yyyymmdd.slice(4, 6)
+  const dd = yyyymmdd.slice(6, 8)
+  return new Date(`${yyyy}-${mm}-${dd}`)
+}
+
+const Dday = computed(() => {
+  if (!props.favorite.reqst_end_date) return 'D-?'
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const end = parseDate(props.favorite.reqst_end_date)
+  end.setHours(0, 0, 0, 0)
+
+  const dday = Math.ceil((end - today) / (1000 * 60 * 60 * 24))
+
+  if (dday === 0) return 'D-day'
+
+  if (dday > 0) return `D-${dday}`
+
+  return '마감'
+})
+</script>
+
+<template>
+  <RouterLink
+    :to="{ name: 'announceDetail', params: { announce_id: props.favorite.announce_id } }"
+    custom
+    v-slot="{ navigate }"
+  >
+    <div
+      class="bg-white rounded-xl h-[8rem] flex flex-col justify-between shadow-[0px_4px_8px_1px_rgba(0,0,0,0.22)] p-4 hover:cursor-pointer"
+      @click="navigate"
+    >
+      <div class="flex justify-between gap-4">
+        <h1 class="text-start text-12 semibold">{{ props.favorite.announce_title }}</h1>
+        <div class="flex flex-col items-center">
+          <Icon icon="material-symbols:kid-star" class="size-7 text-green" />
+          <div
+            class="w-[2.5rem] h-[1.1rem] text-10 semibold rounded-[5px] flex items-center justify-center text-white"
+            :class="
+              Dday === '마감'
+                ? 'bg-gray-300'
+                : Dday === 'D-day'
+                  ? 'bg-red'
+                  : Number(Dday.replace('D-', '')) <= 5
+                    ? 'bg-red'
+                    : 'bg-blue'
+            "
+          >
+            {{ Dday }}
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="flex items-center justify-between">
+          <button
+            class="flex items-center reqular text-14 bg-pink-100 text-white p-1 px-2 rounded-[7px]"
+            @click.stop="$router.push('/')"
+          >
+            서류 준비하기
+            <Icon icon="material-symbols:arrow-forward-ios-rounded" />
+          </button>
+          <div class="flex flex-col items-end">
+            <p class="text-10 bold">서류 준비도: 65%</p>
+            <div class="w-[10rem] h-2 bg-gray-200 rounded-full">
+              <div class="h-2 bg-blue rounded-full" style="width: 65%"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </RouterLink>
+</template>
+
+<style scoped></style>

--- a/KB-Hackerton-client/src/components/layouts/DefaultLayout.vue
+++ b/KB-Hackerton-client/src/components/layouts/DefaultLayout.vue
@@ -4,7 +4,9 @@ import { RouterView } from 'vue-router'
 
 <template>
   <div class="w-full flex-1 min-h-0 flex flex-col overflow-hidden">
-    <div class="w-full flex-1 min-h-0 overflow-y-auto px-4 pt-4 pb-[34px]">
+    <div
+      class="w-full flex-1 min-h-0 overflow-y-auto [&::-webkit-scrollbar]:hidden px-4 pt-4 pb-[34px]"
+    >
       <RouterView />
     </div>
   </div>

--- a/KB-Hackerton-client/src/views/FavoritesView.vue
+++ b/KB-Hackerton-client/src/views/FavoritesView.vue
@@ -1,7 +1,18 @@
-<script setup></script>
+<script setup>
+import FavoriteCard from '@/components/favorite/FavoriteCard.vue'
+import announce from '@/_dummy/announce.json'
+
+const favoriteAnnounceList = announce.filter((a) => a.is_favorite)
+</script>
 
 <template>
-  <div class="w-full text-center">즐겨찾기</div>
+  <div class="w-full text-center flex flex-col gap-5 mb-10">
+    <FavoriteCard
+      v-for="announce in favoriteAnnounceList"
+      :key="announce.announce_id"
+      :favorite="announce"
+    />
+  </div>
 </template>
 
 <style scoped></style>


### PR DESCRIPTION
<!--- 제목 ex: [Feat]: 공지사항 목록 뷰 퍼블리싱-->

## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #35
> Close #이슈번호

## 📄 PR 상세 내용
<!--- 작업에 대한 설명을 작성해 주세요. -->
- 즐겨찾기 목록 뷰 퍼블리싱
- 카드 전체 클릭시 공고 상세 뷰 이동
- 서류 준비하기 버튼 클릭시 관련 페이지이동 (아직 관련 페이지가 없어 홈으로 router처리)
- RouterLink custom과 @click.stop을 활용해 카드 전체 클릭 동작과 버튼 클릭 동작이 충돌하지 않도록 분리




# 📸 이미지 
<table>
<tr>
<td>
<img width="393" height="850" alt="image" src="https://github.com/user-attachments/assets/6601f17b-8bd5-4198-94ae-35500342046a" />
</td>
</tr>
</table>
## ❓ 논의하고 싶은 내용

## 📍 레퍼런스
