### PR TITLE
[Feat]: 공고 목록 및 축제 목록 뷰 API 연동

### DIFF
--- a/KB-Hackerton-client/src/views/AnnounceListView.vue
+++ b/KB-Hackerton-client/src/views/AnnounceListView.vue
@@ -20,7 +20,7 @@ const errorMsg = ref('')
 const { announceList } = storeToRefs(announceStore)
 
 // 검색 대상 필드 (널-세이프 문자열 비교)
-const SEARCH_FIELDS = ['announce_title', 'hashtags', 'author', 'exc_InsttNm', 'lcategory']
+const SEARCH_FIELDS = ['title', 'exc_Instt_nm', 'lcategory']
 
 const getTodayYmdNum = () => {
   const d = new Date()

--- a/KB-Hackerton-client/src/views/AnnounceListView.vue
+++ b/KB-Hackerton-client/src/views/AnnounceListView.vue
@@ -1,12 +1,23 @@
 <script setup>
 import AnnouncementCard from '@/components/calendar/AnnouncementCard.vue'
-import announce from '@/_dummy/announce'
-import { computed, ref } from 'vue'
+
+import { computed, onMounted, ref } from 'vue'
 import SearchBarNoneButton from '@/components/input/SearchBarNoneButton.vue'
 import TagSelector from '@/components/common/TagSelector.vue'
+import { useAnnounceStore } from '@/stores/announce'
+import { useFavoriteStore } from '@/stores/favorite'
+import { storeToRefs } from 'pinia'
+import ErrorModal from '@/components/error/ErrorModal.vue'
 
+const announceStore = useAnnounceStore()
+const favoriteStore = useFavoriteStore()
 const filter = ref('전체')
 const searched = ref('')
+
+const errorModal = ref(false)
+const errorMsg = ref('')
+
+const { announceList } = storeToRefs(announceStore)
 
 // 검색 대상 필드 (널-세이프 문자열 비교)
 const SEARCH_FIELDS = ['announce_title', 'hashtags', 'author', 'exc_InsttNm', 'lcategory']
@@ -21,19 +32,20 @@ const getTodayYmdNum = () => {
 
 const displayAnnounceList = computed(() => {
   const t = getTodayYmdNum()
+  const src = Array.isArray(announceList.value) ? announceList.value : []
 
   // 1) 상태/카테고리 1차 필터
   let base = []
   if (filter.value === '마감') {
-    base = announce.filter((a) => a.reqst_end_date < t && a.reqst_end_date !== '') // 마감
+    base = src.filter((a) => a.end_date < t && a.end_date !== null) // 마감
   } else if (filter.value === '접수중') {
-    base = announce.filter((a) => a.reqst_start_date <= t && t <= a.reqst_end_date) // 접수중
+    base = src.filter((a) => (a.start_date <= t || a.pub_date <= t) && t <= a.end_date) // 접수중
   } else if (filter.value === '접수에정') {
-    base = announce.filter((a) => a.reqst_start_date > t) // 접수예정
+    base = src.filter((a) => a.start_date > t || a.pub_date > t) // 접수예정
   } else if (filter.value === '즐겨찾기') {
-    base = announce.filter((a) => a.is_favorite) // 즐겨찾기
+    base = src.filter((a) => a.favorite) // 즐겨찾기
   } else {
-    base = announce.filter((a) => a.reqst_end_date >= t)
+    base = src.filter((a) => a.end_date >= t || a.end_date === null)
   }
 
   // 2) 검색어 2차 필터 (널-세이프 + 소문자 비교)
@@ -43,6 +55,36 @@ const displayAnnounceList = computed(() => {
   return base.filter((item) =>
     SEARCH_FIELDS.some((k) => ((item?.[k] ?? '') + '').toLowerCase().includes(q)),
   )
+})
+
+const setFavorite = async (id, isFavorite) => {
+  if (isFavorite) {
+    await favoriteStore.deleteFavorite(id)
+    if (favoriteStore.error !== null) {
+      errorMsg.value = '즐겨찾기 취소에 실패했습니다.'
+      errorModal.value = true
+      return
+    }
+  } else {
+    await favoriteStore.setFavorite(id)
+    if (favoriteStore.error !== null) {
+      errorMsg.value = '즐겨찾기 등록에 실패했습니다.'
+      errorModal.value = true
+      return
+    }
+  }
+
+  const item = announceList.value?.find((it) => String(it.announce_id) === String(id))
+  if (item) {
+    item.favorite = !isFavorite
+  }
+}
+onMounted(async () => {
+  await announceStore.getAnnounceList()
+  if (announceStore.error) {
+    errorMsg.value = '공고 목록을 불러오는데 실패했습니다.'
+    errorModal.value = true
+  }
 })
 </script>
 
@@ -71,8 +113,22 @@ const displayAnnounceList = computed(() => {
         v-for="announce in displayAnnounceList"
         :key="announce.announce_id"
         :announcement="announce"
+        @updated="(id, isFavorite) => setFavorite(id, isFavorite)"
       />
     </div>
+
+    <div
+      v-if="errorModal"
+      class="fixed inset-0 bg-black/55 z-[90]"
+      @click="errorModal = false"
+    ></div>
+
+    <ErrorModal
+      v-if="errorModal"
+      @close="errorModal = false"
+      :title="errorMsg"
+      class="z-[100] fixed top-1/3 left-1/2 -translate-x-1/2"
+    />
   </div>
 </template>
 

--- a/KB-Hackerton-client/src/views/CalendarView.vue
+++ b/KB-Hackerton-client/src/views/CalendarView.vue
@@ -57,7 +57,7 @@ onMounted(async () => {
 
 const favoriteSet = async (id, isFavorite) => {
   const targetId = String(id) // ✅ 항상 문자열로 통일
-  const desired = !isFavorite // 토글 결과
+  const desired = !isFavorite
 
   if (isFavorite) {
     await favoriteStore.deleteFavorite(targetId)

--- a/KB-Hackerton-client/src/views/FestivalListView.vue
+++ b/KB-Hackerton-client/src/views/FestivalListView.vue
@@ -1,12 +1,19 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import FestivalCard from '@/components/calendar/FestivalCard.vue'
-import festival from '@/_dummy/festival'
 import SearchBarNoneButton from '@/components/input/SearchBarNoneButton.vue'
 import TagSelector from '@/components/common/TagSelector.vue'
+import { useFestivalStore } from '@/stores/festival'
+import { storeToRefs } from 'pinia'
+import ErrorModal from '@/components/error/ErrorModal.vue'
 
+const festivalStore = useFestivalStore()
+const { festivalList } = storeToRefs(festivalStore)
 const filter = ref('전체')
 const searched = ref('')
+
+const errorModal = ref(false)
+const errorMsg = ref('')
 
 // 검색 대상 필드 (널-세이프 문자열 비교)
 const SEARCH_FIELDS = ['festival_title', 'overview', 'add1', 'add2']
@@ -21,19 +28,20 @@ const getTodayYmdNum = () => {
 
 const displayFestivalList = computed(() => {
   const t = getTodayYmdNum()
+  const src = Array.isArray(festivalList.value) ? festivalList.value : []
 
   // 1) 상태/카테고리 1차 필터
   let base = []
   if (filter.value === '마감') {
-    base = festival.filter((a) => a.event_enddate < t) // 마감
+    base = src.filter((a) => a.event_enddate < t) // 마감
   } else if (filter.value === '진행중') {
-    base = festival.filter((a) => a.event_startdate <= t && t <= a.event_enddate) // 진행중
+    base = src.filter((a) => a.event_startdate <= t && t <= a.event_enddate) // 진행중
   } else if (filter.value === '진행전') {
-    base = festival.filter((a) => a.event_startdate > t) // 진행전
+    base = src.filter((a) => a.event_startdate > t) // 진행전
   } else if (filter.value === '올해') {
-    base = festival.filter((a) => String(a.event_enddate).slice(0, 4) === String(t).slice(0, 4)) // 올해
+    base = src.filter((a) => String(a.event_enddate).slice(0, 4) === String(t).slice(0, 4)) // 올해
   } else {
-    base = festival.filter((a) => a.event_enddate >= t)
+    base = src.filter((a) => a.event_enddate >= t)
   }
 
   // 2) 검색어 2차 필터 (널-세이프 + 소문자 비교)
@@ -43,6 +51,14 @@ const displayFestivalList = computed(() => {
   return base.filter((item) =>
     SEARCH_FIELDS.some((k) => ((item?.[k] ?? '') + '').toLowerCase().includes(q)),
   )
+})
+
+onMounted(async () => {
+  await festivalStore.getFestivalList()
+  if (festivalStore.error) {
+    errorMsg.value = '축제 목록을 불러오는데 실패했습니다.'
+    errorModal.value = true
+  }
 })
 </script>
 
@@ -71,6 +87,19 @@ const displayFestivalList = computed(() => {
         :key="festival.festival_id"
       />
     </div>
+
+    <div
+      v-if="errorModal"
+      class="fixed inset-0 bg-black/55 z-[90]"
+      @click="errorModal = false"
+    ></div>
+
+    <ErrorModal
+      v-if="errorModal"
+      @close="errorModal = false"
+      :title="errorMsg"
+      class="z-[100] fixed top-1/3 left-1/2 -translate-x-1/2"
+    />
   </div>
 </template>
 

--- a/KB-Hackerton-client/src/views/FestivalListView.vue
+++ b/KB-Hackerton-client/src/views/FestivalListView.vue
@@ -16,7 +16,7 @@ const errorModal = ref(false)
 const errorMsg = ref('')
 
 // 검색 대상 필드 (널-세이프 문자열 비교)
-const SEARCH_FIELDS = ['festival_title', 'overview', 'add1', 'add2']
+const SEARCH_FIELDS = ['festival_title', 'overview', 'addr']
 
 const getTodayYmdNum = () => {
   const d = new Date()


### PR DESCRIPTION
<!--- 제목 ex: [Feat]: 회원가입 -->

## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #84 
> Close #이슈번호

## 📄 PR 상세 내용
<!--- 작업에 대한 설명을 작성해 주세요. -->
- 공고 목록 및 축제 목록 API 연동
- 공고 즐겨찾기 추가 및 삭제 API 연동


## 📸 이미지 
<table>
<tr>
<td>
<img width="392" height="1093" alt="image" src="https://github.com/user-attachments/assets/fbaac1af-dfc0-479f-8123-f3b9375d5b7d" />
</td>
<td>
<img width="389" height="1084" alt="image" src="https://github.com/user-attachments/assets/6fcb9c4c-5aff-4942-89ab-a40ffbc64cac" />
</td>
</tr>
<tr>
<td>
<img width="393" height="1089" alt="image" src="https://github.com/user-attachments/assets/63601aa8-1a44-495c-9d8b-24f7659ed585" />
</td>
<td>
<img width="391" height="1087" alt="image" src="https://github.com/user-attachments/assets/32c0d56e-dcff-4fe9-a707-855e1eae02c1" />

</td>
</tr>
</table>

## ❓ 논의하고 싶은 내용

## 📍 레퍼런스
